### PR TITLE
reset --hard instead of checkout for SHA

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,8 +114,9 @@ func remote(r *plugin.Repo) *exec.Cmd {
 func checkoutSha(b *plugin.Build) *exec.Cmd {
 	return exec.Command(
 		"git",
-		"checkout",
-		"-qf",
+		"reset",
+		"--hard",
+		"-q",
 		b.Commit.Sha,
 	)
 }


### PR DESCRIPTION
git checkout SHA gives detached head state and some
git operations does not work as expected.

git reset --hard SHA gives identical behavious for files,
but leaves git in clean state

Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>