### PR TITLE
Update submodules when fetching commits

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ password %s
 // configure and customzie the git clone behavior.
 type Params struct {
 	Depth      int  `json:"depth"`
+	Recursive  bool `json:"recursive"`
 	SkipVerify bool `json:"skip_verify"`
 	Tags       bool `json:"tags"`
 }
@@ -88,6 +89,10 @@ func clone(r *plugin.Repo, b *plugin.Build, w *plugin.Workspace, v *Params) erro
 	default:
 		cmds = append(cmds, fetch(b, v.Tags, v.Depth))
 		cmds = append(cmds, checkoutSha(b))
+	}
+
+	if v.Recursive {
+		cmds = append(cmds, updateSubmodules(v.Depth))
 	}
 
 	for _, cmd := range cmds {
@@ -158,6 +163,18 @@ func fetch(b *plugin.Build, tags bool, depth int) *exec.Cmd {
 		fmt.Sprintf("--depth=%d", depth),
 		"origin",
 		fmt.Sprintf("+%s:", b.Ref),
+	)
+}
+
+// updateSubmodules recursively initializes and updates submodules.
+func updateSubmodules(depth int) *exec.Cmd {
+	return exec.Command(
+		"git",
+		"submodule",
+		"update",
+		"--init",
+		"--recursive",
+		fmt.Sprintf("--depth=%d", depth),
 	)
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/drone/drone-plugin-go/plugin"
@@ -14,63 +15,68 @@ import (
 // commits is a list of commits of different types (push, pull request, tag)
 // to help us verify that this clone plugin can handle multiple commit types.
 var commits = []struct {
-	path   string
-	clone  string
-	event  string
-	branch string
-	commit string
-	ref    string
-	file   string
-	data   string
-	tags   []string
+	path       string
+	clone      string
+	event      string
+	branch     string
+	commit     string
+	ref        string
+	file       string
+	data       string
+	tags       []string
+	submodules map[string]string
 }{
 	// first commit
 	{
-		path:   "octocat/Hello-World",
-		clone:  "https://github.com/octocat/Hello-World.git",
-		event:  plugin.EventPush,
-		branch: "master",
-		commit: "553c2077f0edc3d5dc5d17262f6aa498e69d6f8e",
-		ref:    "refs/heads/master",
-		file:   "README",
-		data:   "Hello World!",
-		tags:   nil,
+		path:       "octocat/Hello-World",
+		clone:      "https://github.com/octocat/Hello-World.git",
+		event:      plugin.EventPush,
+		branch:     "master",
+		commit:     "553c2077f0edc3d5dc5d17262f6aa498e69d6f8e",
+		ref:        "refs/heads/master",
+		file:       "README",
+		data:       "Hello World!",
+		tags:       nil,
+		submodules: nil,
 	},
 	// head commit
 	{
-		path:   "octocat/Hello-World",
-		clone:  "https://github.com/octocat/Hello-World.git",
-		event:  plugin.EventPush,
-		branch: "master",
-		commit: "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
-		ref:    "refs/heads/master",
-		file:   "README",
-		data:   "Hello World!\n",
-		tags:   nil,
+		path:       "octocat/Hello-World",
+		clone:      "https://github.com/octocat/Hello-World.git",
+		event:      plugin.EventPush,
+		branch:     "master",
+		commit:     "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+		ref:        "refs/heads/master",
+		file:       "README",
+		data:       "Hello World!\n",
+		tags:       nil,
+		submodules: nil,
 	},
 	// pull request commit
 	{
-		path:   "octocat/Hello-World",
-		clone:  "https://github.com/octocat/Hello-World.git",
-		event:  plugin.EventPull,
-		branch: "master",
-		commit: "553c2077f0edc3d5dc5d17262f6aa498e69d6f8e",
-		ref:    "refs/pull/208/merge",
-		file:   "README",
-		data:   "Goodbye World!\n",
-		tags:   nil,
+		path:       "octocat/Hello-World",
+		clone:      "https://github.com/octocat/Hello-World.git",
+		event:      plugin.EventPull,
+		branch:     "master",
+		commit:     "553c2077f0edc3d5dc5d17262f6aa498e69d6f8e",
+		ref:        "refs/pull/208/merge",
+		file:       "README",
+		data:       "Goodbye World!\n",
+		tags:       nil,
+		submodules: nil,
 	},
 	// branch
 	{
-		path:   "octocat/Hello-World",
-		clone:  "https://github.com/octocat/Hello-World.git",
-		event:  plugin.EventPush,
-		branch: "test",
-		commit: "b3cbd5bbd7e81436d2eee04537ea2b4c0cad4cdf",
-		ref:    "refs/heads/test",
-		file:   "CONTRIBUTING.md",
-		data:   "## Contributing\n",
-		tags:   nil,
+		path:       "octocat/Hello-World",
+		clone:      "https://github.com/octocat/Hello-World.git",
+		event:      plugin.EventPush,
+		branch:     "test",
+		commit:     "b3cbd5bbd7e81436d2eee04537ea2b4c0cad4cdf",
+		ref:        "refs/heads/test",
+		file:       "CONTRIBUTING.md",
+		data:       "## Contributing\n",
+		tags:       nil,
+		submodules: nil,
 	},
 	// tags
 	{
@@ -95,6 +101,22 @@ var commits = []struct {
 			"v1.22",
 			"v1.23",
 		},
+		submodules: nil,
+	},
+	// submodules
+	{
+		path:   "msteinert/drone-git-test-submodule",
+		clone:  "https://github.com/msteinert/drone-git-test-submodule.git",
+		event:  plugin.EventPush,
+		branch: "master",
+		commit: "072ae3ddb6883c8db653f8d4432b07c035b93753",
+		ref:    "refs/heads/master",
+		file:   "Hello-World/README",
+		data:   "Hello World!\n",
+		tags:   nil,
+		submodules: map[string]string{
+			"Hello-World": "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+		},
 	},
 }
 
@@ -105,6 +127,11 @@ func TestClone(t *testing.T) {
 	for _, c := range commits {
 		dir := setup()
 
+		recursive := false
+		if c.submodules != nil {
+			recursive = true
+		}
+
 		tags := false
 		if c.tags != nil {
 			tags = true
@@ -113,7 +140,10 @@ func TestClone(t *testing.T) {
 		r := &plugin.Repo{Clone: c.clone}
 		b := &plugin.Build{Commit: c.commit, Branch: c.branch, Ref: c.ref, Event: c.event}
 		w := &plugin.Workspace{Path: dir}
-		v := &Params{Tags: tags}
+		v := &Params{
+			Recursive: recursive,
+			Tags:      tags,
+		}
 		if err := clone(r, b, w, v); err != nil {
 			t.Errorf("Expected successful clone. Got error. %s.", err)
 		}
@@ -135,6 +165,18 @@ func TestClone(t *testing.T) {
 			}
 		}
 
+		if c.submodules != nil {
+			submodules, err := getSubmodules(dir)
+			if err != nil {
+				t.Error(err)
+			}
+			for k, v := range c.submodules {
+				if submodules[k] != v {
+					t.Errorf("Expected submodule [%s:%s] to exist.", k, v)
+				}
+			}
+		}
+
 		teardown(dir)
 	}
 }
@@ -148,10 +190,23 @@ func TestCloneNonEmpty(t *testing.T) {
 
 	for _, c := range commits {
 
+		recursive := false
+		if c.submodules != nil {
+			recursive = true
+		}
+
+		tags := false
+		if c.tags != nil {
+			tags = true
+		}
+
 		r := &plugin.Repo{Clone: c.clone}
 		b := &plugin.Build{Commit: c.commit, Branch: c.branch, Ref: c.ref, Event: c.event}
 		w := &plugin.Workspace{Path: filepath.Join(dir, c.path)}
-		v := &Params{}
+		v := &Params{
+			Recursive: recursive,
+			Tags:      tags,
+		}
 		if err := clone(r, b, w, v); err != nil {
 			t.Errorf("Expected successful clone. Got error. %s.", err)
 			break
@@ -161,6 +216,30 @@ func TestCloneNonEmpty(t *testing.T) {
 		if data != c.data {
 			t.Errorf("Expected %s to contain [%s]. Got [%s].", c.file, c.data, data)
 			break
+		}
+
+		if c.tags != nil {
+			tags, err := getTags(w.Path)
+			if err != nil {
+				t.Error(err)
+			}
+			for _, tag := range c.tags {
+				if !tags[tag] {
+					t.Errorf("Expected tag [%s] to exist.", tag)
+				}
+			}
+		}
+
+		if c.submodules != nil {
+			submodules, err := getSubmodules(w.Path)
+			if err != nil {
+				t.Error(err)
+			}
+			for k, v := range c.submodules {
+				if submodules[k] != v {
+					t.Errorf("Expected submodule [%s:%s] to exist.", k, v)
+				}
+			}
 		}
 	}
 }
@@ -202,6 +281,49 @@ func TestFetch(t *testing.T) {
 	}
 	for _, td := range testdata {
 		c := fetch(td.build, td.tags, td.depth)
+		if len(c.Args) != len(td.exp) {
+			t.Errorf("Expected: %s, got %s", td.exp, c.Args)
+		}
+		for i := range c.Args {
+			if c.Args[i] != td.exp[i] {
+				t.Errorf("Expected: %s, got %s", td.exp, c.Args)
+			}
+		}
+	}
+}
+
+// TestUpdateSubmodules tests if the arguments to `git submodule update`
+// are constructed properly.
+func TestUpdateSubmodules(t *testing.T) {
+	testdata := []struct {
+		depth int
+		exp   []string
+	}{
+		{
+			50,
+			[]string{
+				"git",
+				"submodule",
+				"update",
+				"--init",
+				"--recursive",
+				"--depth=50",
+			},
+		},
+		{
+			100,
+			[]string{
+				"git",
+				"submodule",
+				"update",
+				"--init",
+				"--recursive",
+				"--depth=100",
+			},
+		},
+	}
+	for _, td := range testdata {
+		c := updateSubmodules(td.depth)
 		if len(c.Args) != len(td.exp) {
 			t.Errorf("Expected: %s, got %s", td.exp, c.Args)
 		}
@@ -265,4 +387,30 @@ func getTags(dir string) (map[string]bool, error) {
 		return nil, err
 	}
 	return tags, nil
+}
+
+// getSubmodules returns all of the submodules in a git repository as a map.
+func getSubmodules(dir string) (map[string]string, error) {
+	cmd := exec.Command("git", "submodule", "status")
+	cmd.Dir = dir
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	submodules := make(map[string]string)
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		a := strings.Split(strings.TrimSpace(scanner.Text()), " ")
+		submodules[a[1]] = a[0]
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if err := cmd.Wait(); err != nil {
+		return nil, err
+	}
+	return submodules, nil
 }


### PR DESCRIPTION
This change emulates the recursive clone option.

A couple things to note:

1. This repo is used for testing: https://github.com/msteinert/drone-git-test-submodule
2. I didn't deal with the git+ssh URL problem you pointed out in Gitter

I think point 2 might be a large-ish feature. I might try to address it in a follow-on PR. It might be OK to punt on it... I would consider submodules to be an advanced feature. We could sternly warn about lurking dragons in the documentation.

Another option might be to completely disregard this PR/feature. Travis-CI deals with this issue by suggesting the user put `git submodule update --init --recursive` in the build script (in the `before_install` section I think).

If you decide to accept this PR you might also consider forking the test repo into a group you control and updating the test case.