### PR TITLE
add "complete" param for non-shallow fetches

### DIFF
--- a/main.go
+++ b/main.go
@@ -175,10 +175,10 @@ func fetch(b *plugin.Build, tags bool, depth int, complete bool) *exec.Cmd {
 	if !complete {
 		cmd.Args = append(cmd.Args, fmt.Sprintf("--depth=%d", depth))
 	}
-	cmd.Args = append(cmd.Args,
-		"origin",
-		fmt.Sprintf("+%s:", b.Ref),
-	)
+	cmd.Args = append(cmd.Args, "origin")
+	if b.Ref != "" {
+		cmd.Args = append(cmd.Args, fmt.Sprintf("+%s:", b.Ref))
+	}
 	return cmd
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -247,15 +247,17 @@ func TestCloneNonEmpty(t *testing.T) {
 // TestClone tests if the arguments to `git fetch` are constructed properly.
 func TestFetch(t *testing.T) {
 	testdata := []struct {
-		build *plugin.Build
-		tags  bool
-		depth int
-		exp   []string
+		build    *plugin.Build
+		tags     bool
+		depth    int
+		complete bool
+		exp      []string
 	}{
 		{
 			&plugin.Build{Ref: "refs/heads/master"},
 			false,
 			50,
+			false,
 			[]string{
 				"git",
 				"fetch",
@@ -269,6 +271,7 @@ func TestFetch(t *testing.T) {
 			&plugin.Build{Ref: "refs/heads/master"},
 			true,
 			100,
+			false,
 			[]string{
 				"git",
 				"fetch",
@@ -278,9 +281,22 @@ func TestFetch(t *testing.T) {
 				"+refs/heads/master:",
 			},
 		},
+		{
+			&plugin.Build{Ref: "refs/heads/master"},
+			false,
+			50,
+			true,
+			[]string{
+				"git",
+				"fetch",
+				"--no-tags",
+				"origin",
+				"+refs/heads/master:",
+			},
+		},
 	}
 	for _, td := range testdata {
-		c := fetch(td.build, td.tags, td.depth)
+		c := fetch(td.build, td.tags, td.depth, td.complete)
 		if len(c.Args) != len(td.exp) {
 			t.Errorf("Expected: %s, got %s", td.exp, c.Args)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -254,6 +254,19 @@ func TestFetch(t *testing.T) {
 		exp      []string
 	}{
 		{
+			&plugin.Build{Ref: ""},
+			false,
+			50,
+			false,
+			[]string{
+				"git",
+				"fetch",
+				"--no-tags",
+				"--depth=50",
+				"origin",
+			},
+		},
+		{
 			&plugin.Build{Ref: "refs/heads/master"},
 			false,
 			50,


### PR DESCRIPTION
Shallow fetches are more efficient, but sometimes you need all of the
history. Setting a sufficiently large depth is not a good workaround for 2 reasons:

1. Setting a large depth like 2345678 (which, let's say, is
   effectively infinity) in the YAML actually fails with the following
   error:

   ```
   panic: Unable to unarmshal vargs. json: cannot unmarshal number 2.345678e+06 into Go value of type int
   ```

2. All shallow clones require the usage of a temporary scratch
   file/dir (in cgit), and they can't use the fast-path that full-history
   clones use.

The reason you sometimes need all of the history is if you want to
build a commit that's very old. For example, a commit that's the
1000th-old commit on a branch would require a depth of 1000, but it's
unlikely that the builder would know how many commits ago the commit
was. So, the builder would need to avoid using shallow clones
altogether.