### PR TITLE
Add Dockerfile for the armhf architecture

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,0 +1,9 @@
+# Docker image for Drone's git-clone plugin (armhf architecture)
+#
+#     CGO_ENABLED=0 go build -a -tags netgo
+#     docker build --rm=true -f Dockerfile.armhf -t plugins/git:armhf .
+
+FROM armhfbuild/alpine:3.2
+RUN apk add -U ca-certificates git openssh curl perl && rm -rf /var/cache/apk/*
+ADD drone-git /bin/
+ENTRYPOINT ["/bin/drone-git"]


### PR DESCRIPTION
So, building a Dockerfile for armhf is quite unglamorous. 

I am using an [Alpine base image which is built on Drone](https://github.com/armhf-docker-library/alpine/blob/armhf-drone/.drone.yml). (It's a dirty fork of the original image from the hub.) We could also use [the one which is built by tianon from Docker](https://hub.docker.com/r/armhf/alpine/), but I am not sure those images will stay, because they are marked as experimental.