### PR TITLE
Support Git LFS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,14 @@
 
 FROM alpine:3.2
 RUN apk add -U ca-certificates git openssh curl perl && rm -rf /var/cache/apk/*
+
+ENV LFS_VERSION 1.2.0
+RUN curl -sLO https://github.com/github/git-lfs/releases/download/v${LFS_VERSION}/git-lfs-linux-amd64-${LFS_VERSION}.tar.gz && \
+    tar xzf /git-lfs-linux-amd64-${LFS_VERSION}.tar.gz -C / && \
+    mv /git-lfs-${LFS_VERSION}/git-lfs /usr/local/bin/ && \
+    git-lfs init && \
+    rm -rf /git-lfs-${LFS_VERSION} && \
+    rm -rf /git-lfs-linux-amd64-${LFS_VERSION}.tar.gz
+
 ADD drone-git /bin/
 ENTRYPOINT ["/bin/drone-git"]


### PR DESCRIPTION
## Description

Mostly inspired from:

https://github.com/groob/docker-git-sync/blob/1481fcae9fdca1fda3d8b4fca67dd142c5713b8b/Dockerfile

Obvious fix.

## Status

Tested, you can try it by yourself with:

```
docker pull bbenoist/drone-git:0.5-alt-lfs
docker run --rm -e DRONE_REMOTE_URL=https://github.com/lbergelson/test-git-lfs -e DRONE_WORKSPACE=/go/src/github.com/lbergelson/test-git -e DRONE_BUILD_EVENT=push -e DRONE_COMMIT_SHA=4260d027e55ba83f62f7d193e13982f57004e89b -e DRONE_COMMIT_REF=refs/heads/master bbenoist/drone-git:0.5-alt-lfs
```

Which should output the following:

```
...
<command>git reset --hard -q 4260d027e55ba83f62f7d193e13982f57004e89b</command>
**Downloading another_large_file.txt (31 B)**
**Downloading large_file.txt (53 B)**
<command>git submodule update --init --recursive</command>
```

## Warning

Please understand the consequences of this changes. Most important are:
* Any Git repository with files indexed by Git LFS will trigger the corresponding downloads when checking out (only if non-existing or different)
* Pushes will also upload new artefacts.
* Git LFS can use a different server than the source of a cloned Git repository

Depending on your approach, it might be better to provide an option for disabling it.