### PR TITLE
Added git --global flag to remapSubmodule to support multi-level recursive HTTPS …

### DIFF
--- a/main.go
+++ b/main.go
@@ -215,6 +215,7 @@ func remapSubmodule(name, url string) *exec.Cmd {
 	return exec.Command(
 		"git",
 		"config",
+		"--global",
 		name,
 		url,
 	)


### PR DESCRIPTION
…checkout (more than one level)

I needed to add this and use it to get a successful checkout of recursive submodules using overwrites of the submodule url. The current version (drone-plugins/drone-git master) only support one level of private submodule checkouts. The corresponding test only checks that. I am not a go programmer, so extending the test would take me a lot of time.
