### PR TITLE
Set default clone depth to 1 (shallow clone)

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func main() {
 		},
 		cli.IntFlag{
 			Name:   "depth",
+			Value:	1,
 			Usage:  "clone depth",
 			EnvVar: "PLUGIN_DEPTH",
 		},


### PR DESCRIPTION
This should speed up cloning large repositories (e.g. linux kernel).

Is there any reason we can't make it the default?