### PR TITLE
Fix commit hash in test file

### DIFF
--- a/plugin_test.go
+++ b/plugin_test.go
@@ -48,7 +48,7 @@ var commits = []struct {
 		clone:  "https://github.com/octocat/Hello-World.git",
 		event:  "pull_request",
 		branch: "master",
-		commit: "553c2077f0edc3d5dc5d17262f6aa498e69d6f8e",
+		commit: "43617d6cc59d91c7d99909042c19ff122e2597fb",
 		ref:    "refs/pull/208/merge",
 		file:   "README",
 		data:   "Goodbye World!\n",


### PR DESCRIPTION
I think this pr will be helpful to solve a problem at #38 

```
% git init
Initialized empty Git repository in /Users/yosuke_ota/test/.git/
% git remote add origin https://github.com/octocat/Hello-World.git
% git fetch --no-tags origin +refs/pull/208/merge:
remote: Counting objects: 11, done.
remote: Total 11 (delta 0), reused 0 (delta 0), pack-reused 11
Unpacking objects: 100% (11/11), done.
From https://github.com/octocat/Hello-World
 * branch            refs/pull/208/merge -> FETCH_HEAD
% git rev-parse FETCH_HEAD
43617d6cc59d91c7d99909042c19ff122e2597fb
```