### PR TITLE
Allow passing remote, url, sha and ref via .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ pipeline:
   publish:
     image: plugins/docker
     repo: plugins/git
-    tags: [ "latest", "1.2", "1" ]
+    tags: [ "latest", "1.3", "1" ]
     when:
       branch: master
       event: push

--- a/main.go
+++ b/main.go
@@ -21,23 +21,23 @@ func main() {
 		cli.StringFlag{
 			Name:   "remote",
 			Usage:  "git remote url",
-			EnvVar: "DRONE_REMOTE_URL",
+			EnvVar: "PLUGIN_REMOTE,DRONE_REMOTE_URL",
 		},
 		cli.StringFlag{
 			Name:   "path",
 			Usage:  "git clone path",
-			EnvVar: "DRONE_WORKSPACE",
+			EnvVar: "PLUGIN_PATH,DRONE_WORKSPACE",
 		},
 		cli.StringFlag{
 			Name:   "sha",
 			Usage:  "git commit sha",
-			EnvVar: "DRONE_COMMIT_SHA",
+			EnvVar: "PLUGIN_SHA,DRONE_COMMIT_SHA",
 		},
 		cli.StringFlag{
 			Name:   "ref",
 			Value:  "refs/heads/master",
 			Usage:  "git commit ref",
-			EnvVar: "DRONE_COMMIT_REF",
+			EnvVar: "PLUGIN_REF,DRONE_COMMIT_REF",
 		},
 		cli.StringFlag{
 			Name:   "event",


### PR DESCRIPTION
I have this in my own fork and it's been working great for me.  :)

Think it could be useful for others needing a simple way to clone more projects into their pipeline.