### PR TITLE
only fetch apk cache once

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.label-schema.name="Drone Git"
 LABEL org.label-schema.vendor="Drone.IO Community"
 LABEL org.label-schema.schema-version="1.0"
 
-RUN apk add -U --no-cache ca-certificates git openssh curl perl
+RUN apk add --no-cache ca-certificates git openssh curl perl
 
 ADD release/linux/amd64/drone-git /bin/
 ENTRYPOINT ["/bin/drone-git"]

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -7,7 +7,7 @@ LABEL org.label-schema.name="Drone Git"
 LABEL org.label-schema.vendor="Drone.IO Community"
 LABEL org.label-schema.schema-version="1.0"
 
-RUN apk add -U --no-cache ca-certificates git openssh curl perl
+RUN apk add --no-cache ca-certificates git openssh curl perl
 
 ADD release/linux/arm/drone-git /bin/
 ENTRYPOINT ["/bin/drone-git"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -7,7 +7,7 @@ LABEL org.label-schema.name="Drone Git"
 LABEL org.label-schema.vendor="Drone.IO Community"
 LABEL org.label-schema.schema-version="1.0"
 
-RUN apk add -U --no-cache ca-certificates git openssh curl perl
+RUN apk add --no-cache ca-certificates git openssh curl perl
 
 ADD release/linux/arm64/drone-git /bin/
 ENTRYPOINT ["/bin/drone-git"]


### PR DESCRIPTION
The `-U` flag fetches the apk cache and stores it in /var/cache/apk.  The `--no-cache` flag fetches the apk cache, but doesn't store it.  Using both flags results in the apk cache being fetched twice.  Additionally, the cache files end up in the resulting image.

See also https://github.com/drone-plugins/drone-base/pull/1.

```
$ docker run -it --rm --entrypoint /bin/sh plugins/git:1.3.0
/ # du -h /var/cache/apk
1.1M	/var/cache/apk
```