### PR TITLE
Adding an "attempts" parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,12 @@ func main() {
 			Usage:  "skip tls verification",
 			EnvVar: "PLUGIN_SKIP_VERIFY",
 		},
+		cli.IntFlag{
+			Name: "attempts",
+			Usage: "clone attempts",
+			EnvVar: "PLUGIN_ATTEMPTS",
+			Value: 1,
+		},
 		cli.BoolFlag{
 			Name:   "submodule-update-remote",
 			Usage:  "update remote submodules",
@@ -138,6 +144,7 @@ func run(c *cli.Context) error {
 		},
 		Config: Config{
 			Depth:           c.Int("depth"),
+			Attempts:        c.Int("attempts"),
 			Tags:            c.Bool("tags"),
 			Recursive:       c.BoolT("recursive"),
 			SkipVerify:      c.Bool("skip-verify"),

--- a/plugin.go
+++ b/plugin.go
@@ -21,12 +21,15 @@ type Plugin struct {
 
 func (p Plugin) Exec() error {
 	var err error
-	for i := 0; i < p.Backoff.Attempts ; i++ {
-		fmt.Println("Exec attempt ", i)
+	if p.Config.Attempts > 1 {
+		fmt.Println("We will do up to", p.Config.Attempts,"attempts")
+	}
+	for i := 0; i < p.Config.Attempts; i++ {
 		err = p.ExecActual()
 		if err == nil {
 			return nil
 		}
+		fmt.Println("Global retry attempt", i)
 		os.RemoveAll(p.Build.Path)
 	}
 	return err
@@ -166,14 +169,14 @@ func checkoutSha(commit string) *exec.Cmd {
 // fetch retuns git command that fetches from origin. If tags is true
 // then tags will be fetched.
 func fetch(ref string, tags bool, depth int) *exec.Cmd {
-	tags_option := "--no-tags"
+	tagsOption := "--no-tags"
 	if tags {
-		tags_option = "--tags"
+		tagsOption = "--tags"
 	}
 	cmd := exec.Command(
 		"git",
 		"fetch",
-		tags_option,
+		tagsOption,
 	)
 	if depth != 0 {
 		cmd.Args = append(cmd.Args, fmt.Sprintf("--depth=%d", depth))

--- a/plugin.go
+++ b/plugin.go
@@ -84,7 +84,17 @@ func (p Plugin) Exec() error {
 // shouldRetry returns true if the command should be re-executed. Currently
 // this only returns true if the remote ref does not exist.
 func shouldRetry(s string) bool {
-	return strings.Contains(s, "find remote ref")
+	if strings.Contains(s, "is empty") {
+		return true
+	}
+	if strings.Contains(s,"The remote end hung up unexpectedly") {
+		return true
+	}
+	if strings.Contains(s, "find remote ref") {
+		return true
+	}
+	fmt.Sprintln("Did not retry after receiving:", s)
+	return false
 }
 
 // retryExec is a helper function that retries a command.

--- a/types.go
+++ b/types.go
@@ -31,6 +31,7 @@ type (
 		Tags            bool
 		Submodules      map[string]string
 		SubmoduleRemote bool
+		Attempts        int
 	}
 
 	Backoff struct {


### PR DESCRIPTION
The "attempts" parameter would allow to re-attempt the complete git fetching process.

Because of the bitbucket recent failure, we had lots of errors like that:
```
git fetch --no-tags origin +refs/heads/feature-florent-drone-tests:
error: object file .git/objects/0f/e959b1c94448cd98cd381f55adda7616ecd9b5 is empty
error: object file .git/objects/0f/e959b1c94448cd98cd381f55adda7616ecd9b5 is empty
fatal: loose object 0fe959b1c94448cd98cd381f55adda7616ecd9b5 (stored in .git/objects/0f/e959b1c94448cd98cd381f55adda7616ecd9b5) is corrupt
```
Which were caused by _something_ during the git fetching process. Retrying to execute the command was my first attempt and it didn't work. What did work was cleaning up the build directory and restarting the whole git cloning process.

I understand if you don't want to add something like that. Please consider the fact that many repositories might act strangely and this kind of option allow to mitigate the problem.