### PR TITLE
git-lfs support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ LABEL org.label-schema.name="Drone Git"
 LABEL org.label-schema.vendor="Drone.IO Community"
 LABEL org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache ca-certificates git openssh curl perl
+RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
+RUN git lfs install
 
 ADD release/linux/amd64/drone-git /bin/
 ENTRYPOINT ["/bin/drone-git"]

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -7,7 +7,8 @@ LABEL org.label-schema.name="Drone Git"
 LABEL org.label-schema.vendor="Drone.IO Community"
 LABEL org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache ca-certificates git openssh curl perl
+RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
+RUN git lfs install
 
 ADD release/linux/arm/drone-git /bin/
 ENTRYPOINT ["/bin/drone-git"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -7,7 +7,8 @@ LABEL org.label-schema.name="Drone Git"
 LABEL org.label-schema.vendor="Drone.IO Community"
 LABEL org.label-schema.schema-version="1.0"
 
-RUN apk add --no-cache ca-certificates git openssh curl perl
+RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
+RUN git lfs install
 
 ADD release/linux/arm64/drone-git /bin/
 ENTRYPOINT ["/bin/drone-git"]


### PR DESCRIPTION
Alpine has added a git-lfs package.  Install and initialize it so that repos using LFS clone properly.

https://bugs.alpinelinux.org/issues/7092

