### PR TITLE
Use a case instead of if as pattern matching does not work with version of /bin/sh

### DIFF
--- a/posix/clone-pull-request
+++ b/posix/clone-pull-request
@@ -4,14 +4,17 @@
 REF="pull/${DRONE_PULL_REQUEST}/head"
 
 # pull request ref, bitbucket
-if [[ $DRONE_REMOTE_URL = "https://bitbucket.org/"* ]]; then
-	REF="refs/pull-requests/${DRONE_PULL_REQUEST}/from"
-fi
+case "$DRONE_REMOTE_URL" in
+    "https://bitbucket.org/"*) REF="refs/pull-requests/${DRONE_PULL_REQUEST}/from" ;;
+    *) ;;
+esac
 
 # pull request ref, gitlab
-if [[ $DRONE_COMMIT_REF = "refs/merge-requests/"* ]]; then
-	REF="refs/merge-requests/${DRONE_PULL_REQUEST}/head"
-fi
+# case being used because pattern matching in /bin/sh needs case.
+case "$DRONE_COMMIT_REF" in
+    "refs/merge-requests/"*) REF="refs/merge-requests/${DRONE_PULL_REQUEST}/head" ;;
+    *) ;;
+esac
 
 FLAGS=""
 if [[ ! -z "${PLUGIN_DEPTH}" ]]; then

--- a/posix/clone-pull-request
+++ b/posix/clone-pull-request
@@ -4,13 +4,14 @@
 REF="pull/${DRONE_PULL_REQUEST}/head"
 
 # pull request ref, bitbucket
+# case being used because pattern matching in /bin/sh needs to use case.
 case "$DRONE_REMOTE_URL" in
     "https://bitbucket.org/"*) REF="refs/pull-requests/${DRONE_PULL_REQUEST}/from" ;;
     *) ;;
 esac
 
 # pull request ref, gitlab
-# case being used because pattern matching in /bin/sh needs case.
+# case being used because pattern matching in /bin/sh needs to use case.
 case "$DRONE_COMMIT_REF" in
     "refs/merge-requests/"*) REF="refs/merge-requests/${DRONE_PULL_REQUEST}/head" ;;
     *) ;;


### PR DESCRIPTION
We have started using this git functionality due to problems with rebasing not triggering drone - but we are GitLab users and found that the if statements wouldn't work. I determined this was down to the version of /bin/sh packaged within alpine.

For more information on this, check out this SO post.
https://stackoverflow.com/a/19897118/31161
