### PR TITLE
Allow cloning using specified SSH key

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,6 +47,11 @@ func main() {
 			EnvVar: "DRONE_BUILD_EVENT",
 		},
 		cli.StringFlag{
+			Name:   "private-ssh-key",
+			Usage:  "private ssh key",
+			EnvVar: "DRONE_PRIVATE_SSH_KEY",
+		},
+		cli.StringFlag{
 			Name:   "netrc.machine",
 			Usage:  "netrc machine",
 			EnvVar: "DRONE_NETRC_MACHINE",
@@ -135,6 +140,9 @@ func run(c *cli.Context) error {
 			Login:    c.String("netrc.username"),
 			Machine:  c.String("netrc.machine"),
 			Password: c.String("netrc.password"),
+		},
+		Ssh: Ssh{
+			PrivateKey: c.String("private-ssh-key"),
 		},
 		Config: Config{
 			Depth:           c.Int("depth"),

--- a/plugin.go
+++ b/plugin.go
@@ -15,6 +15,7 @@ type Plugin struct {
 	Repo    Repo
 	Build   Build
 	Netrc   Netrc
+	Ssh     Ssh
 	Config  Config
 	Backoff Backoff
 }
@@ -27,9 +28,16 @@ func (p Plugin) Exec() error {
 		}
 	}
 
-	err := writeNetrc(p.Netrc.Machine, p.Netrc.Login, p.Netrc.Password)
-	if err != nil {
-		return err
+	if p.Ssh.PrivateKey != "" {
+		err := writeSshKey(p.Ssh.PrivateKey)
+		if err != nil {
+			return err
+		}
+	} else {
+		err := writeNetrc(p.Netrc.Machine, p.Netrc.Login, p.Netrc.Password)
+		if err != nil {
+			return err
+		}
 	}
 
 	var cmds []*exec.Cmd

--- a/types.go
+++ b/types.go
@@ -24,6 +24,10 @@ type (
 		Password string
 	}
 
+	Ssh struct {
+		PrivateKey string
+	}
+
 	Config struct {
 		Depth           int
 		Recursive       bool

--- a/utils.go
+++ b/utils.go
@@ -66,3 +66,25 @@ machine %s
 login %s
 password %s
 `
+
+// helper function to write specified private SSH key
+func writeSshKey(key string) error {
+	if key == "" {
+		return nil
+	}
+	out := fmt.Sprintf(key)
+
+	home := "/root"
+	u, err := user.Current()
+	if err == nil {
+		home = u.HomeDir
+	}
+	sshpath := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(sshpath, 0700); err != nil {
+		return err
+	}
+	confpath := filepath.Join(sshpath, "config")
+	privpath := filepath.Join(sshpath, "id_rsa")
+	ioutil.WriteFile(confpath, []byte("StrictHostKeyChecking no\n"), 0700)
+	return ioutil.WriteFile(privpath, []byte(out), 0600)
+}


### PR DESCRIPTION
To give some context, we are looking to adopt Drone to use our main CI system. Our developers tend to use personal accounts for use within our GitHub organisation, and I have received feedback that they are not comfortable allow the level of permissions that by default requests. I'm aware of that this is a limitation of GitHub (https://github.com/drone/drone/issues/309#issuecomment-176271104) itself.

Drone does allow you to manually set the scope, and this is something we'd like to make use of. We were thinking of allowing the permissions `repo:status` and `write:repo_hook` to activate repositories, but this does not allow the initial cloning of the repository. As an aside, we're also considering giving this function to a single "super admin" at a bootstrap stage, and then only allowing enough functions to login, which the developers would be happy with. I am interested in contributing more granular permissions on a per-user basis in the future (maybe `DRONE_GITHUB_SCOPE_ADMIN` and `DRONE_GITHUB_SCOPE_USER`).

Using this build of the plugin I added a secret as specified in the docs to an SSH key (the public part is assigned to the machine user), and then had to overwrite the remote URL within the `.drone.yml` file:

```
clone:
  git:
    image: surminus/drone-git
    depth: 1
    secrets: [ drone_private_ssh_key ]
    environment:
      PLUGIN_REMOTE: git@github.com:our-secret/repo.git
```

Having this key is useful since we also have some private Gems within GitHub so can use the same key to fetch these.

I'm aware using SSH keys was removed in previous versions, but this change allows control over the key and user.

I'd like to put a disclaimer that I haven't written much Go so have mostly pinched previous code and amended it to my needs, and I wasn't sure about adding tests, so would be happy to receive feedback!

## Commit

The motivation behind this commit is that we wish to administer Drone using a single "machine user" that has access to a restricted set of repositories rather than our individual GitHub user accounts that require setting permissions that are more permissive than we are comfortable with.

This allows passing in the "DRONE_PRIVATE_SSH_KEY" environment variable at clone time, which can be configured using the "secrets" parameter. The repository would have to be configured to fetch using `git@github` which can also be done by passing in an enviornment variable.

If the environment variable is not detected, then it falls back to the standard method of using `.netrc`.