### PR TITLE
Run plugin as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM alpine:3.6
-RUN apk add --no-cache ca-certificates git openssh curl perl
+RUN apk add --no-cache ca-certificates git openssh curl perl sudo
 
 ADD posix/* /usr/local/bin/
+RUN adduser -g Drone -s /bin/sh -D -u 1000 drone
+RUN echo 'drone ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/drone
+USER drone:drone
 ENTRYPOINT ["/usr/local/bin/clone"]

--- a/posix/clone
+++ b/posix/clone
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 sudo mkdir -p ${DRONE_WORKSPACE}
-sudo chown drone:drone ${DRONE_WORKSPACE}
+[ "${CI}" = "drone" ] && sudo chown drone:drone ${DRONE_WORKSPACE}
 cd ${DRONE_WORKSPACE}
 
 # if the netrc enviornment variables exist, write

--- a/posix/clone
+++ b/posix/clone
@@ -1,13 +1,14 @@
 #!/bin/sh
 
-mkdir -p ${DRONE_WORKSPACE}
+sudo mkdir -p ${DRONE_WORKSPACE}
+sudo chown drone:drone ${DRONE_WORKSPACE}
 cd ${DRONE_WORKSPACE}
 
 # if the netrc enviornment variables exist, write
 # the netrc file.
 
 if [[ ! -z "${DRONE_NETRC_MACHINE}" ]]; then
-	cat <<EOF > /root/.netrc
+	cat <<EOF > ${HOME}/.netrc
 machine ${DRONE_NETRC_MACHINE}
 login ${DRONE_NETRC_USERNAME}
 password ${DRONE_NETRC_PASSWORD}
@@ -19,12 +20,12 @@ fi
 # known hosts file.
 
 if [[ ! -z "${SSH_KEY}" ]]; then
-	mkdir /root/.ssh
-	echo -n "$SSH_KEY" > /root/.ssh/id_rsa
-	chmod 600 /root/.ssh/id_rsa
+	mkdir ${HOME}/.ssh
+	echo -n "$SSH_KEY" > ${HOME}/.ssh/id_rsa
+	chmod 600 ${HOME}/.ssh/id_rsa
 
-	touch /root/.ssh/known_hosts
-	chmod 600 /root/.ssh/known_hosts
+	touch ${HOME}/.ssh/known_hosts
+	chmod 600 ${HOME}/.ssh/known_hosts
 	ssh-keyscan -H ${DRONE_NETRC_MACHINE} > /etc/ssh/ssh_known_hosts 2> /dev/null
 fi
 

--- a/posix/clone
+++ b/posix/clone
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 sudo mkdir -p ${DRONE_WORKSPACE}
-[ "${CI}" = "drone" ] && sudo chown drone:drone ${DRONE_WORKSPACE}
+[ -n "${CI}" ] && sudo chown drone:drone ${DRONE_WORKSPACE}
 cd ${DRONE_WORKSPACE}
 
 # if the netrc enviornment variables exist, write

--- a/posix/clone
+++ b/posix/clone
@@ -1,7 +1,11 @@
 #!/bin/sh
 
-sudo mkdir -p ${DRONE_WORKSPACE}
-[ -n "${CI}" ] && sudo chown drone:drone ${DRONE_WORKSPACE}
+if [[ -n "${CI}" ]]; then
+	sudo mkdir -p ${DRONE_WORKSPACE}
+	sudo chown drone:drone ${DRONE_WORKSPACE}
+else
+	mkdir -p ${DRONE_WORKSPACE}
+fi
 cd ${DRONE_WORKSPACE}
 
 # if the netrc enviornment variables exist, write


### PR DESCRIPTION
Background: https://www.reddit.com/r/droneci/comments/8opfxw/build_using_docker_image_with_user_directive/

This seems to work fine in my testing, except other non-root plugins can't write to the top level of the workspace (`${DRONE_WORKSPACE}/BUILD` for example).  Based on the [workspace docs](http://docs.drone.io/workspace/), I thought that the volume mount point was the workspace base (`/drone`).  Is that the case?  The permissions errors I got seem to indicate that the volume is mounted at the full workspace path (`/drone/src/github.com/${DRONE_REPO}`).