### PR TITLE
git-lfs support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.6
-RUN apk add --no-cache ca-certificates git openssh curl perl sudo
+FROM alpine:3.7
+RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl sudo
 
 ADD posix/* /usr/local/bin/
 RUN adduser -g Drone -s /bin/sh -D -u 1000 drone


### PR DESCRIPTION
This re-implements #65 off the next branch.  It does require bumping the base image to Alpine 3.7 (git-lfs isn't packaged for 3.6).  I don't know if you're ready for that, but here's the PR for when you are.