### PR TITLE
Clone PR with merge

### DIFF
--- a/posix/clone-pull-request
+++ b/posix/clone-pull-request
@@ -34,7 +34,7 @@ git fetch ${FLAGS} origin +refs/heads/${DRONE_BRANCH}:
 git checkout ${DRONE_BRANCH}
 
 git fetch origin ${REF}:
-git rebase ${DRONE_COMMIT}
+git merge ${DRONE_COMMIT}
 
 # git clone ${FLAGS} -b ${DRONE_BRANCH} --single-branch ${DRONE_REMOTE_URL} \
 #   ${DRONE_WORKSPACE}


### PR DESCRIPTION
Extend the clone-pull-request unittest to expose a flaw in using `rebase`.
Then fix this flaw by switching to `merge` instead.