### PR TITLE
read env-file from PLUGIN_ENV_FILE env var

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,6 +110,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "env-file",
 			Usage: "source env file",
+			EnvVar: "PLUGIN_ENV_FILE",
 		},
 	}
 


### PR DESCRIPTION
We should be able to read an env_file in the clone step

```
- name: detect_pullrequest
  image: alpine
  commands:
      - echo "DRONE_BUILD_EVENT=pull_request" >> .env_file
      - echo "DRONE_COMMIT_REF=refs/pull-requests/1/from" >> .env_file

- name: pullrequest_clone
  image: drone/git
  settings:
      env_file: .env_file
  depends_on:
      - detect_pullrequest
```